### PR TITLE
Spec Gnosis Chain withdrawals

### DIFF
--- a/execution.md
+++ b/execution.md
@@ -5,4 +5,4 @@ _TODO_
 - [ ] AuRa
 - [ ] POSDAO
 - [ ] POSDAO post-merge
-- [ ] Withdrawals
+- [Withdrawals](./execution/withdrawals.md)

--- a/execution/withdrawals.md
+++ b/execution/withdrawals.md
@@ -41,7 +41,7 @@ payload: PAYLOAD
 
 `PAYLOAD` is the ABI encoded arguments for a solidity function with ABI
 
-```c#
+```solidity
 function withdraw(uint256 amount, address address)
 ```
 

--- a/execution/withdrawals.md
+++ b/execution/withdrawals.md
@@ -8,10 +8,11 @@ Provide a way for beacon chain withdrawals to enter into the EVM. Extends [ether
 
 ## Specification
 
-| Name                  | Value |
-| --------------------- | ----- |
-| `FORK_TIMESTAMP`      | `TBD` |
-| `WITHDRAWAL_CONTRACT` | `TBD` |
+| Name                  | Value                                        |
+| --------------------- | -------------------------------------------- |
+| `FORK_TIMESTAMP`      | `TBD`                                        |
+| `WITHDRAWAL_CONTRACT` | `TBD`                                        |
+| `SYSTEM_SENDER`       | `0xfffffffffffffffffffffffffffffffffffffffe` |
 
 Beginning with the execution timestamp `FORK_TIMESTAMP`, execution clients **MUST** introduce the following extensions to payload validation and processing:
 
@@ -29,6 +30,7 @@ The `withdrawals` in an execution payload are processed **after** any user-level
 For each `withdrawal` in the list of `execution_payload.withdrawals`, the implementation must construct and execute an EVM transaction as follows:
 
 ```
+sender: SYSTEM_SENDER
 max_priority_fee_per_gas: TBD
 max_fee_per_gas: TBD
 gas_limit: TBD

--- a/execution/withdrawals.md
+++ b/execution/withdrawals.md
@@ -1,0 +1,68 @@
+# Withdrawals
+
+Support validator withdrawals from the beacon chain to the EVM via a "system-level" operation type.
+
+## Motivation
+
+Provide a way for beacon chain withdrawals to enter into the EVM. Extends [ethereum/eip-4895](https://eips.ethereum.org/EIPS/eip-4895) but instead of minting native tokens calls an predefined contract which disperses a non-native tokens.
+
+## Specification
+
+| Name                  | Value |
+| --------------------- | ----- |
+| `FORK_TIMESTAMP`      | `TBD` |
+| `WITHDRAWAL_CONTRACT` | `TBD` |
+
+Beginning with the execution timestamp `FORK_TIMESTAMP`, execution clients **MUST** introduce the following extensions to payload validation and processing:
+
+The following sections of [ethereum/eip-4895](https://eips.ethereum.org/EIPS/eip-4895#system-level-operation-withdrawal) are implemented un-altered
+
+- System-level operation: withdrawal
+- New field in the execution payload: withdrawals
+- New field in the execution payload header: withdrawals root
+- Execution payload validity
+
+**State transition**
+
+The `withdrawals` in an execution payload are processed **after** any user-level transactions are applied.
+
+For each `withdrawal` in the list of `execution_payload.withdrawals`, the implementation must construct and execute an EVM transaction as follows:
+
+```
+max_priority_fee_per_gas: TBD
+max_fee_per_gas: TBD
+gas_limit: TBD
+destination: WITHDRAWAL_CONTRACT
+amount: 0
+payload: PAYLOAD
+```
+
+`PAYLOAD` is the ABI encoded arguments for a solidity function with ABI
+
+```c#
+function withdraw(uint256 amount, address address)
+```
+
+Where `amount` equals `withdrawal.amount` and `address` equals `withdrawal.address`.
+
+If the transaction reverts, or runs out of the gas, the entire block **MUST** be considered invalid.
+
+## Rationale
+
+### Why does the EIP-4895 need to be modified?
+
+Gnosis Beacon Chain stakes a non-native token (GNO), while Ethereum stakes its native token (ETH). Gnosis Chain native token (xDAI) must only be minted when bridging DAI from Ethereum mainnet, to mantain its 1:1 peg with Ethereum DAI tokens. This introduces the mandatory requirement to at least disable the state transition as defined in EIP-4895.
+
+A withdrawal from the Gnosis Beacon Chain must trigger the release of GNO from an EVM contract. This can potentially be achieved at the consensus level with a system transaction as proposed here. However, since those tokens are already available at the EVM, it is possible to conditionally release them by proving to a contract that a withdrawal was included in a canonical block. Such a strategy would require constant upkeep, and given the expected rate of withdrawals it was deemed to risky and expensive.
+
+### Why general EVM execution instead of just modifying storage?
+
+Given that a transfer or ERC20 tokens is required, modifying the state directly would restrict the implementation of the withdrawal contract too much. Existing Gnosis Chain execution nodes already perform system level operations against the BlockRewards contract of POSDAO. So general EVM execution is consistent with the status quo.
+
+## Backwards Compatibility
+
+No issues
+
+## Security Considerations
+
+TBA

--- a/execution/withdrawals.md
+++ b/execution/withdrawals.md
@@ -33,7 +33,7 @@ The implementation must construct and execute one system EVM transaction as foll
 sender: SYSTEM_SENDER
 max_priority_fee_per_gas: 0
 max_fee_per_gas: 0
-gas_limit: 1600000
+gas_limit: 30000000
 destination: WITHDRAWAL_CONTRACT
 amount: 0
 payload: PAYLOAD


### PR DESCRIPTION
Spec Gnosis Chain withdrawals, extending [ethereum/eip-4895](https://eips.ethereum.org/EIPS/eip-4895).

Content and todos

- [x] Spec
- [x] Rationale
- (_TBD_) Constants
- (_TBA_) Security considerations

CC: @LukaszRozmej @jmederosalvarado @yperbasis