### PR TITLE
Update withdrawal system function

### DIFF
--- a/execution/withdrawals.md
+++ b/execution/withdrawals.md
@@ -42,7 +42,7 @@ payload: PAYLOAD
 `PAYLOAD` is the ABI encoded arguments for a solidity function with ABI
 
 ```solidity
-function withdrawals(uint64[] amounts, address[] addresses)
+function executeSystemWithdrawals(uint64[] amounts, address[] addresses)
 ```
 
 Where `amounts` is the consecutive collection of each `withdrawal.amount` as GWei, and `addresses` is the consecutive collection of each `withdrawal.address`. `WITHDRAWAL_CONTRACT` must assert that `amounts` and `addresses` are of the same length.


### PR DESCRIPTION
Rename 

```solidity
function withdrawals(uint64[] amounts, address[] addresses)
```

to

```solidity
function executeSystemWithdrawals(uint64[] amounts, address[] addresses)
```

As suggested by @Barichek and @rubo in https://github.com/gnosischain/deposit-contract/pull/25/files#r1105858646

> I like this better as I prefer the function name to be a verb. So, either this one or just withdraw. And since this function is called from the execution client, I need to know what name to use. If we stick with this one, the spec needs to be updated.