### PR TITLE
Set eip4844 blob limits to 1/2

### DIFF
--- a/network-upgrades/dencun.md
+++ b/network-upgrades/dencun.md
@@ -27,8 +27,8 @@ Gnosis chain has significantly cheaper fees than mainnet, so blob spam is a conc
 | Constant | Value |
 | -------- | ----- |
 | MIN_BLOB_GASPRICE | 1000000000 |
-| TARGET_BLOB_GAS_PER_BLOCK | TBD |
-| MAX_BLOB_GAS_PER_BLOCK | TBD |
+| TARGET_BLOB_GAS_PER_BLOCK | 131072 |
+| MAX_BLOB_GAS_PER_BLOCK | 262144 |
 
 ### [EIP-7514](https://eips.ethereum.org/EIPS/eip-7514)
 

--- a/network-upgrades/dencun.md
+++ b/network-upgrades/dencun.md
@@ -29,6 +29,7 @@ Gnosis chain has significantly cheaper fees than mainnet, so blob spam is a conc
 | MIN_BLOB_GASPRICE | 1000000000 |
 | TARGET_BLOB_GAS_PER_BLOCK | 131072 |
 | MAX_BLOB_GAS_PER_BLOCK | 262144 |
+| BLOB_GASPRICE_UPDATE_FRACTION | 1112826 |
 
 ### [EIP-7514](https://eips.ethereum.org/EIPS/eip-7514)
 


### PR DESCRIPTION
**Justification**

Impact of the block size on Gnosis network performance, and reasoning for 1/2 choice: https://hackmd.io/@5qNKk0aeQlygax4hX3rVXw/SkY3dBV-6

**Big blocks experiment summary**

![photo_2023-10-05_08-21-52](https://github.com/gnosischain/specs/assets/35266934/dde20046-5ca8-4c30-8301-87ecdbcd206c)

Noticeable degradation on the bucket 250-500Kb. Tolerable degradation on 130-262Kb. 

**Comparision to Ethereum rate**

Per time rate = `3 * 5/12 / 6 * 5/12` = `1.25 / 2.5`

**Proposal**

1/2 is a conservation choice that should not increase network latency beyond key thresholds. Increasing this values can be done latter in response to demand and only requires changes on the execution layer clients.

Closes https://github.com/gnosischain/specs/issues/18