### PR TITLE
Expand Low Level Shutter Spec

### DIFF
--- a/shutter/low-level.md
+++ b/shutter/low-level.md
@@ -267,14 +267,6 @@ Transactions `txs[j]` for `j >= 1` are a subset of `decrypted_transactions`. The
 >
 > :construction: :construction: :construction:
 
-### Decryption Key Relay
-
-> :construction: :construction: :construction:
->
-> Todo
->
-> :construction: :construction: :construction:
-
 ## Smart Contracts
 
 This section specifies the interfaces and behavior of the smart contracts in the protocol. The id of the chain on which they are deployed is `CHAIN_ID`.

--- a/shutter/low-level.md
+++ b/shutter/low-level.md
@@ -601,8 +601,26 @@ def hash_gt_to_block(preimage: GT) -> Block:
 def hash_bytes_to_block(preimage: bytes) -> Block:
     return keccak256(preimage)
 
-def encode_gt(value: GT) -> bytes:
-    pass  # TODO
+def encode_gt(v: GT) -> bytes:
+    # elements from GT decompose into two elements x and y from the sixth-degree extension field GF(P^6)
+    # elements from GF(P^6) decompose into three elements x, y, and z from the second-degree extension field GF(P^2)
+    # elements from GF(P^2) decompose into two elements x and y from the finite field GF(P)
+    # GF(P) is the Galois field of order ORDER, called F_p in EIPs 196 and 197, consisting of integers modulo ORDER.
+    ints: Sequence[int] = [
+        v.x.x.x,
+        v.x.x.y,
+        v.x.y.x,
+        v.x.y.y,
+        v.x.z.x,
+        v.x.z.y,
+        v.y.x.x,
+        v.y.x.y,
+        v.y.y.x,
+        v.y.y.y,
+        v.y.z.x,
+        v.y.z.y,
+    ]
+    return b"".join([i.to_bytes(32, "big") for i in ints])
 
 def xor_blocks(block1: Block, block2: Block) -> Block:
     return Block(bytes(b1 ^ b2 for b1, b2 in zip(block1, block2)))

--- a/shutter/low-level.md
+++ b/shutter/low-level.md
@@ -285,7 +285,7 @@ The Sequencer is a contract deployed at address `SEQUENCER_ADDRESS`. It implemen
 
 ```solidity
 interface ISequencer {
-    function submitEncryptedTransaction(uint64 eon, bytes32 identityPrefix, address sender, bytes memory encryptedTransaction, uint256 gasLimit) external;
+    function submitEncryptedTransaction(uint64 eon, bytes32 identityPrefix, bytes memory encryptedTransaction, uint256 gasLimit) external;
     function submitDecryptionProgress(bytes memory message) external;
 
     event TransactionSubmitted(uint64 eon, bytes32 identityPrefix, address sender, bytes encryptedTransaction, uint256 gasLimit);


### PR DESCRIPTION
This PR expands `/shutter/low-level.md`. In particular, it

- specifies the encrypting RPC server.
- fixes a malleability vulnerability.
- defines the `encode_gt` function, the last missing crypto function.
- removes the section on the decryption key relay (which is not needed anymore as Nethermind has a libp2p implementation now).