### PR TITLE
Shutter: Curve update and hash functions

### DIFF
--- a/shutter/low-level.md
+++ b/shutter/low-level.md
@@ -87,7 +87,7 @@ def make_decryption_key_shares_message(
         instanceID=INSTANCE_ID,
         eon=eon,
         keyperIndex=keyper_index,
-        slot=s,
+        slot=slot,
         txPointer=tx_pointer + len(txs),
         shares=shares,
         signature=signature,
@@ -201,13 +201,13 @@ The keyper processes the following `DecryptionKeys` messages:
 If a message `keys_message` is not valid according to `check_decryption_keys_message(keys_message, eon)` it is ignored:
 
 ```python
-def check_decryption_keys_message(keys_message: DecryptionKeys, eon: uint64, threshold: uint64) -> bool:
+def check_decryption_keys_message(keys_message: DecryptionKeys, eon: uint64, eon_public_key: bytes, threshold: uint64) -> bool:
     if keys_message.instanceID != INSTANCE_ID or keys_message.eon != eon:
         return False
 
     if not all(
         check_decryption_key(key_message.key, eon_public_key, key.identity)
-        for key in keys.keys
+        for key in keys_message.keys
     ):
         return False
 
@@ -218,6 +218,8 @@ def check_decryption_keys_message(keys_message: DecryptionKeys, eon: uint64, thr
         return False
     if len(keys_message.signatures) != threshold:
         return False
+
+    keypers: List[Address] = get_keyper_set()
 
     return all(
         check_slot_decryption_identities_signature(
@@ -821,7 +823,7 @@ def generate_hash(
         instance_id=instance_id,
         eon=eon,
         slot=slot,
-        identities=[encode_g1(identity) for identity for identities],
+        identities=[encode_g1(identity) for identity in identities],
     )
     return ssz.hash_tree_root(sdi)
 

--- a/shutter/low-level.md
+++ b/shutter/low-level.md
@@ -556,17 +556,17 @@ This section defines the cryptographic primitives used in the protocol.
 
 ### Definitions
 
-| Type                                              | Description                                                                                                                      |
-| ------------------------------------------------- | -------------------------------------------------------------------------------------------------------------------------------- |
-| `G1`                                              | An element of the BN256-group G1 as defined in [EIP-197](https://eips.ethereum.org/EIPS/eip-197#definition-of-the-groups)        |
-| `G2`                                              | An element of the BN256-group G2 as defined in [EIP-197](https://eips.ethereum.org/EIPS/eip-197#definition-of-the-groups)        |
-| `GT`                                              | An element of the BN256-group GT, the range of the pairing function defined in [EIP-197](https://eips.ethereum.org/EIPS/eip-197) |
-| `Block`                                           | A 32-byte block                                                                                                                  |
-| `EncryptedMessage` = (G2, Block, Sequence[Block]) | An encrypted message                                                                                                             |
-| `ECDSAPrivkey`                                    | A secp256k1 ECDSA private key                                                                                                    |
-| `ECDSASignature`                                  | A secp256k1 ECDSA signature encoded in format `R ++ S ++ V` where `V` is `0` or `1`                                              |
-| `Address`                                         | An Ethereum address                                                                                                              |
-| `uint64`                                          | An unsigned 64 bit integer                                                                                                       |
+| Type                                              | Description                                                                         |
+| ------------------------------------------------- | ----------------------------------------------------------------------------------- |
+| `G1`                                              | An element of the first BLS12-381 subgroup                                          |
+| `G2`                                              | An element of the second BLS12-381 subgroup                                         |
+| `GT`                                              | An element of the BLS12-381 pairing target group                                    |
+| `Block`                                           | A 32-byte block                                                                     |
+| `EncryptedMessage` = (G2, Block, Sequence[Block]) | An encrypted message                                                                |
+| `ECDSAPrivkey`                                    | A secp256k1 ECDSA private key                                                       |
+| `ECDSASignature`                                  | A secp256k1 ECDSA signature encoded in format `R ++ S ++ V` where `V` is `0` or `1` |
+| `Address`                                         | An Ethereum address                                                                 |
+| `uint64`                                          | An unsigned 64 bit integer                                                          |
 
 | Constant | Description                   | Value                                                                         |
 | -------- | ----------------------------- | ----------------------------------------------------------------------------- |
@@ -574,18 +574,18 @@ This section defines the cryptographic primitives used in the protocol.
 
 The following functions are considered prerequisites:
 
-| Function                       | Description                                                                                     |
-| ------------------------------ | ----------------------------------------------------------------------------------------------- |
-| keccak256(bytes) -> Block      | The keccak-256 hash function                                                                    |
-| pairing(G1, G2) -> GT          | The pairing function specified in [EIP-197](https://eips.ethereum.org/EIPS/eip-197)             |
-| g1_add(G1, G1) -> G1           | Add two elements of G1                                                                          |
-| g1_scalar_mult(G1, int) -> G1  | Multiply an element of G1 by a scalar                                                           |
-| g1_scalar_base_mult(int) -> G1 | Multiply the generator of G1 by a scalar                                                        |
-| g2_scalar_base_mult(int) -> G2 | Multiply the generator of G2 by a scalar                                                        |
-| gt_exp(GT, int) -> GT          | Exponentiate an element of GT by a scalar                                                       |
-| encode_g1(G1) -> bytes         | Encode an element of G1 according to [EIP-197](https://eips.ethereum.org/EIPS/eip-197#encoding) |
-| encode_g2(G2) -> bytes         | Encode an element of G2 according to [EIP-197](https://eips.ethereum.org/EIPS/eip-197#encoding) |
-| decode_g2(bytes) -> G2         | Decode an element of G2 according to [EIP-197](https://eips.ethereum.org/EIPS/eip-197#encoding) |
+| Function                       | Description                               |
+| ------------------------------ | ----------------------------------------- |
+| keccak256(bytes) -> Block      | The keccak-256 hash function              |
+| pairing(G1, G2) -> GT          | The BLS12-381 pairing function            |
+| g1_add(G1, G1) -> G1           | Add two elements of G1                    |
+| g1_scalar_mult(G1, int) -> G1  | Multiply an element of G1 by a scalar     |
+| g1_scalar_base_mult(int) -> G1 | Multiply the generator of G1 by a scalar  |
+| g2_scalar_base_mult(int) -> G2 | Multiply the generator of G2 by a scalar  |
+| gt_exp(GT, int) -> GT          | Exponentiate an element of GT by a scalar |
+| encode_g1(G1) -> bytes         | Encode an element of G1                   |
+| encode_g2(G2) -> bytes         | Encode an element of G2                   |
+| decode_g2(bytes) -> G2         | Decode an element of G2                   |
 
 ### Helper Functions
 
@@ -612,7 +612,7 @@ def encode_gt(v: GT) -> bytes:
     # elements from GT decompose into two elements x and y from the sixth-degree extension field GF(P^6)
     # elements from GF(P^6) decompose into three elements x, y, and z from the second-degree extension field GF(P^2)
     # elements from GF(P^2) decompose into two elements x and y from the finite field GF(P)
-    # GF(P) is the Galois field of order ORDER, called F_p in EIPs 196 and 197, consisting of integers modulo ORDER.
+    # GF(P) is the Galois field of order ORDER, consisting of integers modulo ORDER.
     ints: Sequence[int] = [
         v.x.x.x,
         v.x.x.y,

--- a/shutter/low-level.md
+++ b/shutter/low-level.md
@@ -778,12 +778,17 @@ def encode_decryption_key(decryption_key: G1) -> bytes:
 def encode_decryption_key_share(decryption_key_share: G1) -> bytes:
     return encode_g1(decryption_key_share)
 
+CRYPTO_VERSION: byte = str(0x02).encode()
+
 def encode_encrypted_message(encrypted_message: EncryptedMessage) -> bytes:
     c1, c2, c3 = encrypted_message
-    return encode_g2(c1) + c2 + b"".join(c3)
+    return CRYPTO_VERSION + encode_g2(c1) + c2 + b"".join(c3)
 
 def decode_encrypted_message(b: bytes) -> EncryptedMessage:
+    version_id = b[0]
+    b = b[1:]
     assert len(b) > 4 * 32 + 32 + 32
+    assert version_id == CRYPTO_VERSION
     c1_bytes = b[:4 * 32]
     c2 = b[4 * 32: 5 * 32]
     c3_bytes = b[5 * 32:]

--- a/shutter/low-level.md
+++ b/shutter/low-level.md
@@ -580,7 +580,7 @@ The following functions are considered prerequisites:
 | g1_scalar_mult(G1, int) -> G1  | Multiply an element of G1 by a scalar                                                           |
 | g1_scalar_base_mult(int) -> G1 | Multiply the generator of G1 by a scalar                                                        |
 | g2_scalar_base_mult(int) -> G2 | Multiply the generator of G2 by a scalar                                                        |
-| gt_scalar_mult(GT, int) -> GT  | Multiply an element of GT by a scalar                                                           |
+| gt_exp(GT, int) -> GT          | Exponentiate an element of GT by a scalar                                                       |
 | encode_g1(G1) -> bytes         | Encode an element of G1 according to [EIP-197](https://eips.ethereum.org/EIPS/eip-197#encoding) |
 | encode_g2(G2) -> bytes         | Encode an element of G2 according to [EIP-197](https://eips.ethereum.org/EIPS/eip-197#encoding) |
 | decode_g2(bytes) -> G2         | Decode an element of G2 according to [EIP-197](https://eips.ethereum.org/EIPS/eip-197#encoding) |
@@ -716,7 +716,7 @@ def compute_c1(r: int) -> G2:
 
 def compute_c2(sigma: Block, r: int, identity: G1, eon_key: G2) -> Block:
     p = pairing(identity, eon_key)
-    preimage = gt_scalar_mult(p, r)
+    preimage = gt_exp(p, r)
     key = hash2(preimage)
     return xor_blocks(sigma, key)
 


### PR DESCRIPTION
This PR updates the crypto functions:

- ensure used hash functions are distinct by prefixing the preimages
- use BLS12-381 instead of BN256
- add a version identifier to encrypted messages
- rename `gt_scalar_mult` to `gt_exp`