### PR TITLE
Easier to run assert_declare_ethereum_vars script

### DIFF
--- a/.github/workflows/ethereum_config_check.yml
+++ b/.github/workflows/ethereum_config_check.yml
@@ -16,11 +16,8 @@ jobs:
       with:
         python-version: '3.x'
 
-    - name: Install PyYAML
-      run: pip install PyYAML
-
     - name: Check keys
       # --dev checks against an unpinned commit. since new vars can be added at any time unpinned commits
       # are checked on a cron, not on regular flows.
-      run: python scripts/assert_declare_ethereum_vars.py
+      run: ./scripts/assert_declare_ethereum_vars.sh
 

--- a/scripts/assert_declare_ethereum_vars.sh
+++ b/scripts/assert_declare_ethereum_vars.sh
@@ -1,0 +1,4 @@
+python3 -m venv venv
+source "venv/bin/activate"
+pip install pyyaml
+python ./scripts/assert_declare_ethereum_vars.py


### PR DESCRIPTION
At least in my environment running `python assert_declare_ethereum_vars.py` does not recognize the global installation of pyyaml. This wrapper script `assert_declare_ethereum_vars.sh` should work on all envs