### PR TITLE
Remove temp note for `MAX_BLOBS_PER_BLOCK_ELECTRA`

### DIFF
--- a/beacon_chain.md
+++ b/beacon_chain.md
@@ -32,8 +32,8 @@ ETHEREUM_SPEC_COMMIT: v1.5.0-beta.2
 | `MIN_EPOCHS_FOR_BLOB_SIDECARS_REQUESTS` | `4096`        | `16384`      | Increased to match the expected 2 weeks rollups consider today for Ethereum mainnet. The total disk requirement roughly equivalent to Ethereum mainnet since epochs are 4.8x faster |
 | `MAX_BLOBS_PER_BLOCK`                   | `6`           | `2`          | See [/network-upgrades/dencun.md#eip-4844](/network-upgrades/dencun.md#eip-4844) for rationale on choosing 1/2 for the Dencun hard fork |
 | `MAX_PER_EPOCH_ACTIVATION_EXIT_CHURN_LIMIT` | `256000000000` | `64000000000` | Match the modified value `MAX_PER_EPOCH_ACTIVATION_CHURN_LIMIT` https://github.com/gnosischain/specs/pull/22 for rationale |
-| `MAX_BLOBS_PER_BLOCK_ELECTRA`           | `9`           | `2`          | Temporary value equal to `MAX_BLOBS_PER_BLOCK` |
-| `BLOB_SIDECAR_SUBNET_COUNT_ELECTRA`     | `9`           | `2`          | No blob capacity scheduled, see [/network-upgrades/dencun.md#eip-4844](/network-upgrades/dencun.md#eip-4844) for rationale on choosing 1/2 | 
+| `MAX_BLOBS_PER_BLOCK_ELECTRA`           | `9`           | `2`          | No blob capacity scheduled, see [/network-upgrades/dencun.md#eip-4844](/network-upgrades/dencun.md#eip-4844) for rationale on choosing 1/2 | 
+| `BLOB_SIDECAR_SUBNET_COUNT_ELECTRA`     | `9`           | `2`          | Equal to `MAX_BLOBS_PER_BLOCK_ELECTRA` |
 | `MAX_REQUEST_BLOB_SIDECARS_ELECTRA`     | `1152`        | `256`        | Make the constant match `MAX_BLOBS_PER_BLOCK_ELECTRA * MAX_BLOCKS_PER_REQUEST` |
 | `MAX_BLOBS_PER_BLOCK_FULU`              | `12`          | `2`          | Temporary value equal to `MAX_BLOBS_PER_BLOCK` |
 | `MIN_EPOCHS_FOR_DATA_COLUMN_SIDECARS_REQUESTS` | `4096` | `16384`      | Increased to match the expected 2 weeks rollups consider today for Ethereum mainnet |


### PR DESCRIPTION
No blob capacity scheduled, see [/network-upgrades/dencun.md#eip-4844](https://github.com/gnosischain/specs/blob/master/network-upgrades/dencun.md#eip-4844) for rationale on choosing 1/2