### PR TITLE
Fix preset name (Mainnet -> Gnosis)

### DIFF
--- a/consensus/preset/gnosis/altair.yaml
+++ b/consensus/preset/gnosis/altair.yaml
@@ -1,4 +1,4 @@
-# Mainnet preset - Altair
+# Gnosis preset - Altair
 
 # Updated penalty values
 # ---------------------------------------------------------------

--- a/consensus/preset/gnosis/bellatrix.yaml
+++ b/consensus/preset/gnosis/bellatrix.yaml
@@ -1,4 +1,4 @@
-# Mainnet preset - Bellatrix
+# Gnosis preset - Bellatrix
 
 # Updated penalty values
 # ---------------------------------------------------------------

--- a/consensus/preset/gnosis/capella.yaml
+++ b/consensus/preset/gnosis/capella.yaml
@@ -1,4 +1,4 @@
-# Mainnet preset - Capella
+# Gnosis preset - Capella
 
 # Misc
 # Max operations per block

--- a/consensus/preset/gnosis/deneb.yaml
+++ b/consensus/preset/gnosis/deneb.yaml
@@ -1,4 +1,4 @@
-# Mainnet preset - Deneb
+# Gnosis preset - Deneb
 
 # Misc
 # ---------------------------------------------------------------

--- a/consensus/preset/gnosis/electra.yaml
+++ b/consensus/preset/gnosis/electra.yaml
@@ -1,4 +1,4 @@
-# Mainnet preset - Electra
+# Gnosis preset - Electra
 
 # Gwei values
 # ---------------------------------------------------------------

--- a/consensus/preset/gnosis/phase0.yaml
+++ b/consensus/preset/gnosis/phase0.yaml
@@ -1,4 +1,4 @@
-# Mainnet preset - Phase0
+# Gnosis preset - Phase0
 
 # Misc
 # ---------------------------------------------------------------


### PR DESCRIPTION
Probably a result of copy-pasting from the Ethereum Mainnet presets. Since the Gnosis preset however is called gnosis, I believe it would be good to reflect that here too.