### PR TITLE
Fix formatting

### DIFF
--- a/consensus/preset/gnosis/fulu.yaml
+++ b/consensus/preset/gnosis/fulu.yaml
@@ -2,7 +2,7 @@
 
 # Networking
 # ---------------------------------------------------------------
-# floorlog2(get_generalized_index(BeaconBlockBody, 'blob_kzg_commitments') (= 4)
+# floorlog2(get_generalized_index(BeaconBlockBody, 'blob_kzg_commitments')) (= 4)
 KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH: 4
 
 # Blob


### PR DESCRIPTION
KZG_COMMITMENTS_INCLUSION_PROOF_DEPTH comment has syntax error, misses one of the closing brackets.

Mainnet does not have this:

- https://github.com/ethereum/consensus-specs/blob/v1.7.0-alpha.11/presets/mainnet/fulu.yaml